### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -73,9 +73,9 @@ export async function showSystemNotification(options: NotificationOptions): Prom
 
 		const escapedOptions = {
 			...options,
-			title: title.replace(/"/g, '\\"'),
-			message: message.replace(/"/g, '\\"'),
-			subtitle: options.subtitle?.replace(/"/g, '\\"') || "",
+			title: title.replace(/\\/g, '\\\\').replace(/"/g, '\\"'),
+			message: message.replace(/\\/g, '\\\\').replace(/"/g, '\\"'),
+			subtitle: options.subtitle?.replace(/\\/g, '\\\\').replace(/"/g, '\\"') || "",
 		}
 
 		switch (platform()) {


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/8](https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/8)

To fix the problem, we need to ensure that both backslashes and double quotes are properly escaped in the `message`, `title`, and `subtitle` fields. This can be achieved by using a regular expression that handles both characters. Specifically, we should replace backslashes with double backslashes and double quotes with escaped double quotes.

- Update the `replace` method to handle both backslashes and double quotes.
- Apply the same escaping logic to `title`, `message`, and `subtitle`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
