### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -73,9 +73,9 @@ export async function showSystemNotification(options: NotificationOptions): Prom
 
 		const escapedOptions = {
 			...options,
-			title: title.replace(/"/g, '\\"'),
-			message: message.replace(/"/g, '\\"'),
-			subtitle: options.subtitle?.replace(/"/g, '\\"') || "",
+			title: title.replace(/\\/g, '\\\\').replace(/"/g, '\\"'),
+			message: message.replace(/\\/g, '\\\\').replace(/"/g, '\\"'),
+			subtitle: options.subtitle?.replace(/\\/g, '\\\\').replace(/"/g, '\\"') || "",
 		}
 
 		switch (platform()) {


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/9](https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/9)

To fix the problem, we need to ensure that backslashes are also escaped in addition to double quotes. This can be achieved by using a regular expression to replace both backslashes and double quotes globally. We will update the `replace` method to handle both characters.

- Update the `replace` method to escape backslashes (`\`) before escaping double quotes (`"`).
- Ensure that the changes are applied to all occurrences of the characters in the strings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
