### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete string escaping or encoding

### DIFF
--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -85,7 +85,7 @@ async function globbyLevelByLevel(limit: number, options?: Options) {
 					// Escape parentheses in the path to prevent glob pattern interpretation
 					// This is crucial for NextJS folder naming conventions which use parentheses like (auth), (dashboard)
 					// Without escaping, glob treats parentheses as special pattern grouping characters
-					const escapedFile = file.replace(/\(/g, "\\(").replace(/\)/g, "\\)")
+					const escapedFile = file.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)")
 					queue.push(`${escapedFile}*`)
 				}
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/10](https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/10)

To fix the problem, we need to ensure that backslashes are properly escaped in addition to parentheses. This can be achieved by adding an additional `replace` call to escape backslashes before escaping parentheses. The best way to fix this without changing existing functionality is to modify the line where the escaping is performed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
