### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete string escaping or encoding

### DIFF
--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -85,7 +85,7 @@ async function globbyLevelByLevel(limit: number, options?: Options) {
 					// Escape parentheses in the path to prevent glob pattern interpretation
 					// This is crucial for NextJS folder naming conventions which use parentheses like (auth), (dashboard)
 					// Without escaping, glob treats parentheses as special pattern grouping characters
-					const escapedFile = file.replace(/\(/g, "\\(").replace(/\)/g, "\\)")
+					const escapedFile = file.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)")
 					queue.push(`${escapedFile}*`)
 				}
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/11](https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/11)

To fix the problem, we need to ensure that backslashes are properly escaped in the input string. This can be done by adding a replacement for backslashes before escaping the parentheses. We will use a regular expression with the global flag to replace all occurrences of backslashes with double backslashes. This ensures that any backslashes in the input are properly escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
