### PR TITLE
Potential fix for code scanning alert no. 12: Double escaping or unescaping

### DIFF
--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -8,8 +8,8 @@ export function fixModelHtmlEscaping(text: string): string {
 		.replace(/&gt;/g, ">")
 		.replace(/&lt;/g, "<")
 		.replace(/&quot;/g, '"')
-		.replace(/&amp;/g, "&")
 		.replace(/&apos;/g, "'")
+		.replace(/&amp;/g, "&")
 }
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/12](https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/12)

To fix the problem, we need to ensure that the `&amp;` sequence is replaced last in the `fixModelHtmlEscaping` function. This will prevent any double unescaping issues by ensuring that other HTML entities are correctly unescaped before the `&` character is unescaped.

- Change the order of the replacements in the `fixModelHtmlEscaping` function so that the `&amp;` replacement is performed last.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
