### PR TITLE
Potential fix for code scanning alert no. 13: Client-side cross-site scripting

### DIFF
--- a/webview-ui/src/components/mcp/marketplace/McpMarketplaceCard.tsx
+++ b/webview-ui/src/components/mcp/marketplace/McpMarketplaceCard.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import { McpMarketplaceItem, McpServer } from "../../../../../src/shared/mcp"
 import { vscode } from "../../../utils/vscode"
 import { useEvent } from "react-use"
+import DOMPurify from "dompurify"
 
 interface McpMarketplaceCardProps {
 	item: McpMarketplaceItem
@@ -30,12 +31,13 @@ const McpMarketplaceCard = ({ item, installedServers }: McpMarketplaceCardProps)
 	useEvent("message", handleMessage)
 
 	const githubAuthorUrl = useMemo(() => {
-		const url = new URL(item.githubUrl)
+		const sanitizedUrl = DOMPurify.sanitize(item.githubUrl)
+		const url = new URL(sanitizedUrl)
 		const pathParts = url.pathname.split("/")
 		if (pathParts.length >= 2) {
 			return `${url.origin}/${pathParts[1]}`
 		}
-		return item.githubUrl
+		return sanitizedUrl
 	}, [item.githubUrl])
 
 	return (
@@ -55,7 +57,7 @@ const McpMarketplaceCard = ({ item, installedServers }: McpMarketplaceCardProps)
 				`}
 			</style>
 			<a
-				href={item.githubUrl}
+				href={DOMPurify.sanitize(item.githubUrl)}
 				className="mcp-card"
 				style={{
 					padding: "14px 16px",


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/13](https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/13)

To fix the problem, we need to ensure that the `item.githubUrl` is properly sanitized before being used in the `href` attribute. This can be achieved by using a library like `DOMPurify` to sanitize the URL. This will help prevent any malicious scripts from being executed.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the relevant file.
3. Use `DOMPurify` to sanitize the `item.githubUrl` before using it in the `href` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
