### PR TITLE
Potential fix for code scanning alert no. 15: Client-side cross-site scripting

### DIFF
--- a/webview-ui/src/components/mcp/marketplace/McpMarketplaceCard.tsx
+++ b/webview-ui/src/components/mcp/marketplace/McpMarketplaceCard.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import { McpMarketplaceItem, McpServer } from "../../../../../src/shared/mcp"
 import { vscode } from "../../../utils/vscode"
 import { useEvent } from "react-use"
+import DOMPurify from "dompurify"
 
 interface McpMarketplaceCardProps {
 	item: McpMarketplaceItem
@@ -35,7 +36,7 @@ const McpMarketplaceCard = ({ item, installedServers }: McpMarketplaceCardProps)
 		if (pathParts.length >= 2) {
 			return `${url.origin}/${pathParts[1]}`
 		}
-		return item.githubUrl
+		return DOMPurify.sanitize(item.githubUrl)
 	}, [item.githubUrl])
 
 	return (


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/15](https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/15)

To fix the problem, we need to ensure that the `githubAuthorUrl` is properly sanitized before being used in the `href` attribute of the anchor tag. One effective way to do this is by using a library like `DOMPurify` to sanitize the URL. This will help prevent any malicious content from being executed.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the `McpMarketplaceCard.tsx` file.
3. Use `DOMPurify` to sanitize the `githubAuthorUrl` before using it in the `href` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
