### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -73,9 +73,9 @@ export async function showSystemNotification(options: NotificationOptions): Prom
 
 		const escapedOptions = {
 			...options,
-			title: title.replace(/"/g, '\\"'),
-			message: message.replace(/"/g, '\\"'),
-			subtitle: options.subtitle?.replace(/"/g, '\\"') || "",
+			title: title.replace(/\\/g, '\\\\').replace(/"/g, '\\"'),
+			message: message.replace(/\\/g, '\\\\').replace(/"/g, '\\"'),
+			subtitle: options.subtitle?.replace(/\\/g, '\\\\').replace(/"/g, '\\"') || "",
 		}
 
 		switch (platform()) {


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/7](https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/7)

To fix the problem, we need to ensure that both double quotes and backslashes are properly escaped in the input strings. This can be achieved by using a regular expression with the global flag to replace all occurrences of these characters. We will replace backslashes first to avoid double-escaping issues.

1. Update the `showSystemNotification` function to escape backslashes and double quotes in the `title`, `message`, and `subtitle` fields.
2. Use a regular expression with the global flag to replace all occurrences of backslashes and double quotes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
