### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -502,10 +502,13 @@ export const highlight = (fuseSearchResult: FuseResult<any>[], highlightClassNam
 		let i: number
 
 		for (i = 0; i < pathValue.length - 1; i++) {
+			if (pathValue[i] === "__proto__" || pathValue[i] === "constructor") return
 			obj = obj[pathValue[i]] as Record<string, any>
 		}
 
-		obj[pathValue[i]] = value
+		if (pathValue[i] !== "__proto__" && pathValue[i] !== "constructor") {
+			obj[pathValue[i]] = value
+		}
 	}
 
 	// Function to merge overlapping regions


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/1](https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/1)

To fix the prototype pollution vulnerability, we need to ensure that the `set` function does not allow the modification of `__proto__` or `constructor` properties. This can be achieved by adding a check to skip these properties during the assignment process.

- Modify the `set` function to include a check that skips the `__proto__` and `constructor` properties.
- This change should be made in the `webview-ui/src/components/history/HistoryView.tsx` file, specifically within the `set` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
