### PR TITLE
Potential fix for code scanning alert no. 17: Client-side URL redirect

### DIFF
--- a/webview-ui/src/components/mcp/marketplace/McpMarketplaceCard.tsx
+++ b/webview-ui/src/components/mcp/marketplace/McpMarketplaceCard.tsx
@@ -30,15 +30,19 @@ const McpMarketplaceCard = ({ item, installedServers }: McpMarketplaceCardProps)
 
 	useEvent("message", handleMessage)
 
+	const allowedDomains = useMemo(() => ["github.com", "trusted-domain.com"], [])
+
 	const githubAuthorUrl = useMemo(() => {
 		const sanitizedUrl = DOMPurify.sanitize(item.githubUrl)
 		const url = new URL(sanitizedUrl)
-		const pathParts = url.pathname.split("/")
-		if (pathParts.length >= 2) {
-			return `${url.origin}/${pathParts[1]}`
+		if (allowedDomains.includes(url.hostname)) {
+			const pathParts = url.pathname.split("/")
+			if (pathParts.length >= 2) {
+				return `${url.origin}/${pathParts[1]}`
+			}
 		}
-		return sanitizedUrl
-	}, [item.githubUrl])
+		return ""
+	}, [item.githubUrl, allowedDomains])
 
 	return (
 		<>
@@ -73,7 +77,7 @@ const McpMarketplaceCard = ({ item, installedServers }: McpMarketplaceCardProps)
 					{/* Logo */}
 					{item.logoUrl && (
 						<img
-							src={DOMPurify.sanitize(item.logoUrl)}
+							src={allowedDomains.includes(new URL(DOMPurify.sanitize(item.logoUrl)).hostname) ? DOMPurify.sanitize(item.logoUrl) : ""}
 							alt={`${item.name} logo`}
 							style={{
 								width: 42,


### PR DESCRIPTION
Potential fix for [https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/17](https://github.com/MjrTom/Apex-CodeGenesis-VSCode/security/code-scanning/17)

To fix the problem, we should implement additional validation to ensure that the URLs used for the `img` tag's `src` attribute are from trusted sources. This can be achieved by maintaining a list of allowed domains and checking the sanitized URL against this list before using it. If the URL is not from a trusted domain, we should avoid using it.

1. Create a list of allowed domains.
2. Validate the sanitized URL against this list.
3. Only use the URL if it is from an allowed domain.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
